### PR TITLE
Update installation instructions to specify Nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A git provider for Powershell that helps you to manage and query git repositorie
 Get it throught Nuget:
 
 ```powershell
-Install-Package Pit
+Install-Package Pit -ProviderName Nuget
 
 ```
 


### PR DESCRIPTION
Specify the nuget provider, because the Chocolatey provider has many partial matches for "pit"